### PR TITLE
Fixes 'empty.xml' not found during execution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     keywords='django dia model diagram',
     packages=['django-dia', 'django-dia.management', 'django-dia.management.commands'],
-    package_data={'django-dia.management.commands': ['empty.xml']},
+    package_data={'django-dia': ['empty.xml']},
     install_requires=['Django', 'six'],
     extras_require={
         'tests': ['pytest', 'pytest-django', 'pytest-pythonpath']


### PR DESCRIPTION
Hello,
 
I was willing to try `django-dia` for a good use-case, but when executing `./manage.py make_diagram [...]`, I got a traceback like this one:

```
  File "/home/thomas/work/elearning/venv/lib/python3.5/site-packages/django-dia/management/commands/make_diagram.py", line 72, in handle
    diagram.dia_xml(tables, rels, bezier=options['bezier']),
  File "/home/thomas/work/elearning/venv/lib/python3.5/site-packages/django-dia/diagram.py", line 279, in dia_xml
    dom = ET.fromstring(get_empty_xml())
  File "/home/thomas/work/elearning/venv/lib/python3.5/site-packages/django-dia/diagram.py", line 275, in get_empty_xml
    return pkgutil.get_data(__package__, 'empty.xml')
  File "/usr/lib64/python3.5/pkgutil.py", line 632, in get_data
    return loader.get_data(resource_name)
  File "<frozen importlib._bootstrap_external>", line 850, in get_data
FileNotFoundError: [Errno 2] No such file or directory: '/home/thomas/work/elearning/venv/lib/python3.5/site-packages/django-dia/empty.xml'
``` 

I could not find `empty.xml` into my _virtualenv_, so I fixed `setup.py` to make sure that this `empty.xml` is shipped with _django-dia_. Now, It works in my environment (`Python 3.5`/`Django 2.0.2` inside a _virtualenv_ on an x84_64 gentoo Linux.), after _pip installing_ my fork. I'd like a confirmation from you that you could still use the library in your own environment, I'm not sure about that.

I had issues to run the tests, on my machine, the _test_project_ won't import (`ImportError: No module named 'test_project'`), and for the moment, I can't figure out why. Do not hesitate if you have any idea, otherwise, I'll check this later. Diagrams for my own project are pretty well generated, thanks you ! 

Cheers